### PR TITLE
Fixes a couple more issues, but not finished

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -307,6 +307,7 @@ impl RefreshTokenAuthenticationPayload {
 #[doc(cfg(feature = "broker"))]
 #[derive(Serialize, Clone, Default)]
 struct ExchangePRTPayload {
+    iss: String,
     iat: i64,
     exp: i64,
     client_id: String,
@@ -343,6 +344,7 @@ impl ExchangePRTPayload {
             }
         };
         Ok(ExchangePRTPayload {
+            iss: BROKER_APP_ID.to_string(),
             iat,
             exp,
             client_id: BROKER_CLIENT_IDENT.to_string(),

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -375,6 +375,17 @@ where
 
 #[cfg(feature = "broker")]
 #[doc(cfg(feature = "broker"))]
+fn decode_tgt_cloud<'de, D>(d: D) -> Result<TGTCloud, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let s: String = Deserialize::deserialize(d)?;
+    json_from_str(&s)
+        .map_err(|e| serde::de::Error::custom(format!("Failed parsing tgt_cloud: {}", e)))
+}
+
+#[cfg(feature = "broker")]
+#[doc(cfg(feature = "broker"))]
 #[derive(Clone, Deserialize)]
 pub struct JWEOption {
     #[serde(deserialize_with = "decode_jwe")]
@@ -383,7 +394,7 @@ pub struct JWEOption {
 
 #[cfg(feature = "broker")]
 #[doc(cfg(feature = "broker"))]
-#[derive(Clone, Deserialize)]
+#[derive(Default, Clone, Deserialize)]
 pub struct TGTCloud {
     #[serde(rename = "clientKey")]
     pub client_key: String,
@@ -404,9 +415,9 @@ pub struct TGTCloud {
 #[doc(cfg(feature = "broker"))]
 #[derive(Clone, Deserialize)]
 pub struct PrimaryRefreshToken {
-    pub expires_in: u64,
-    pub ext_expires_in: u64,
-    pub expires_on: u64,
+    pub expires_in: String,
+    pub ext_expires_in: String,
+    pub expires_on: String,
     pub refresh_token: String,
     pub refresh_token_expires_in: u64,
     #[serde(rename = "session_key_jwe")]
@@ -418,7 +429,8 @@ pub struct PrimaryRefreshToken {
     pub client_info: ClientInfo,
     pub device_tenant_id: String,
     pub tgt_error_message: Option<String>,
-    pub tgt_cloud: Option<TGTCloud>,
+    #[serde(deserialize_with = "decode_tgt_cloud", default)]
+    pub tgt_cloud: TGTCloud,
     tgt_client_key: Option<JWEOption>,
     pub kerberos_top_level_names: Option<String>,
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1645,6 +1645,7 @@ impl BrokerClientApplication {
 
         let params = [
             ("grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            ("prt_protocol_version", "3.0"),
             ("request", &signed_jwt),
         ];
         let payload = params


### PR DESCRIPTION
Now I'm getting this error when attempting to exchange the PRT:
AcquireTokenFailed(ErrorResponse { error: "invalid_request", error_description: "AADSTS90023: prt_protocol_version 3.0/4.0 is only supported on v2 Trace ID: d6c54ff8-27f9-444b-9de0-2afef9338800 Correlation ID: d9423a7e-1c69-4891-8f73-60e5597ef422 Timestamp: 2024-01-29 20:11:21Z", error_codes: [90023] })

This could have to do with the way the PRT is requested.