### PR TITLE
Modify enrollment to allow requesting tokens after enroll

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msal"
 description = "Microsoft Authentication Library for Rust"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = [
     "David Mulder <dmulder@suse.com>"


### PR DESCRIPTION
Based on Dirk-jan Mollema's research about
Windows enrollment:
https://dirkjanm.io/phishing-for-microsoft-entra-primary-refresh-tokens/ If we request a refresh token for the resource
https://enrollment.manage.microsoft.com then we
can exchange it both for a enrollment token and
a user PRT later.