### PR TITLE
Utilize a pin code for Windows Hello

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+tags
 
 # Added by cargo
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ uuid = { version = "^1.4.1", features = [ "v4", "serde" ] }
 os-release = "^0.1.0"
 hostname = "^0.3.1"
 openssl = "^0.10.55"
-compact_jwt = { version = "0.3.5", optional = true }
+compact_jwt = { version = "0.4.0-dev", optional = true }
 kanidm-hsm-crypto = { version = "^0.2.0", optional = true }
 regex = "^1.10.3"
 zeroize = { version = "^1.7.0", features = ["zeroize_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msal"
 description = "Microsoft Authentication Library for Rust"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 authors = [
     "David Mulder <dmulder@suse.com>"


### PR DESCRIPTION
This utilizes changes in hsm-crypto which allow
us to set a pin code on the TPM key. This permits
pin code authentication.