### PR TITLE
Failure to initiate MFA can leave garbage in cookies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,9 @@ name: Build
 
 # Trigger the workflow on push or pull request
 "on":
-  push:
-    branches-ignore:
-      - main
   pull_request:
+    branches:
+      - main
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -3,10 +3,9 @@ name: Clippy
 
 # Trigger the workflow on push or pull request
 "on":
-  push:
-    branches-ignore:
-      - main
   pull_request:
+    branches:
+      - main
 
 env:
   SCCACHE_GHA_ENABLED: "true"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "msal"
 description = "Microsoft Authentication Library for Rust"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 authors = [
     "David Mulder <dmulder@suse.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ kanidm-hsm-crypto = { version = "^0.2.0", optional = true }
 regex = "^1.10.3"
 zeroize = { version = "^1.7.0", features = ["zeroize_derive"] }
 scraper = "0.19.0"
+reqwest_cookie_store = "0.7.0"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -2,6 +2,7 @@ use crate::error::{ErrorResponse, MsalError};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use reqwest::{header, Client, Url};
+use reqwest_cookie_store::{CookieStore, CookieStoreMutex};
 use scraper::{Html, Selector};
 use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -9,6 +10,7 @@ use serde_json::{from_str as json_from_str, json, Value};
 use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
+use std::sync::Arc;
 use tracing::info;
 use urlencoding::encode as url_encode;
 use uuid::Uuid;
@@ -738,18 +740,21 @@ impl SessionKey {
 
 struct ClientApplication {
     client: Client,
+    cookie_store: Arc<CookieStoreMutex>,
     client_id: String,
     authority: String,
 }
 
 impl ClientApplication {
     fn new(client_id: &str, authority: Option<&str>) -> Result<Self, MsalError> {
+        let cookie_store = Arc::new(CookieStoreMutex::new(CookieStore::new(None)));
         let client = reqwest::Client::builder()
-            .cookie_store(true)
+            .cookie_provider(std::sync::Arc::clone(&cookie_store))
             .build()
             .map_err(|e| MsalError::RequestFailed(format!("{}", e)))?;
         Ok(ClientApplication {
             client,
+            cookie_store,
             client_id: client_id.to_string(),
             authority: match authority {
                 Some(authority) => authority.to_string(),
@@ -1132,6 +1137,30 @@ impl PublicClientApplication {
     ///   authentication flow.
     /// * Failure: An MsalError, indicating the failure.
     pub async fn initiate_acquire_token_by_mfa_flow(
+        &self,
+        username: &str,
+        password: &str,
+        scopes: Vec<&str>,
+        resource: Option<&str>,
+    ) -> Result<MFAAuthContinue, MsalError> {
+        match self
+            .initiate_acquire_token_by_mfa_flow_internal(username, password, scopes, resource)
+            .await
+        {
+            Ok(res) => Ok(res),
+            Err(e) => {
+                /* If we fail to reset the Cookie store here, subsequent
+                 * auth requests will fail */
+                let mut cookie_store = self.app.cookie_store.lock().map_err(|e| {
+                    MsalError::GeneralFailure(format!("Failed to lock and clear the cookie store. Subsequent authentications will fail: {:?}", e))
+                })?;
+                cookie_store.clear();
+                Err(e)
+            }
+        }
+    }
+
+    async fn initiate_acquire_token_by_mfa_flow_internal(
         &self,
         username: &str,
         password: &str,


### PR DESCRIPTION
If an MFA attempt fails, we need to clear out the
cookies, otherwise subsequent authentication
attempts will hang due to the garbage in the
cookie store.